### PR TITLE
Fixed compatibility issue between the stickyHeader and filter…

### DIFF
--- a/components/datatable/datatable.js
+++ b/components/datatable/datatable.js
@@ -1683,6 +1683,7 @@
 
             //filter support
             this.thead.find('.ui-column-filter').prop('disabled', true);
+            this.filterElements = $this.cloneContainer.find('.ui-column-filter');
         },
 
         _initEditing: function() {


### PR DESCRIPTION
Fixed compatibility issue between the stickyHeader and filter features of puidatatable.

When using stickyHeader and column filters together in the puidatatable, the sticky header covers up the original header including the input fields for the filters. However, the filter function still uses the text in the input fields of the original header, not the sticky header. This change modifies the filterElements array in the _initStickyHeader function so that the filter function uses the input fields in the sticky header instead.