### PR TITLE
Fixes #286 - global filter not working with uppercase values

### DIFF
--- a/components/datatable/datatable.js
+++ b/components/datatable/datatable.js
@@ -1544,7 +1544,7 @@
                 this.options.datasource.call(this, this._onLazyLoad, this._createStateMeta());
             }
             else {
-                var globalFilterValue = $(this.options.globalFilter).val();
+                var globalFilterValue = $(this.options.globalFilter).val().toLowerCase();
                 this.filteredData = [];
 
                 for(var i = 0; i < this.data.length; i++) {


### PR DESCRIPTION
Set the global filter value to lowercase, allowing it to match any case value.