### PR TITLE
Fixes #290 - sorting does not work after filtering

### DIFF
--- a/components/datatable/datatable.js
+++ b/components/datatable/datatable.js
@@ -519,7 +519,9 @@
         _singleSort: function() {
             var $this = this;
 
-            this.data.sort(function(data1, data2) {
+            var dataToSort = this.filteredData ? this.filteredData : this.data;
+
+            dataToSort.sort(function(data1, data2) {
                 var value1 = data1[$this.options.sortField], value2 = data2[$this.options.sortField],
                 result = null;
 

--- a/showcase/demo/datatableFilter.html
+++ b/showcase/demo/datatableFilter.html
@@ -9,10 +9,10 @@
             $('#tblfilter').puidatatable({
                 caption: 'Filtering',
                 columns: [
-                    {field: 'vin', headerText: 'Vin', filter: true},
-                    {field: 'brand', headerText: 'Brand', filter: true},
-                    {field: 'year', headerText: 'Year', filter: true},
-                    {field: 'color', headerText: 'Color', filter: true}
+                    {field: 'vin', headerText: 'Vin', filter: true, sortable: true},
+                    {field: 'brand', headerText: 'Brand', filter: true, sortable: true},
+                    {field: 'year', headerText: 'Year', filter: true, sortable: true},
+                    {field: 'color', headerText: 'Color', filter: true, sortable: true}
                 ],
                 globalFilter:'#globalFilter',
                 datasource: function(callback) {


### PR DESCRIPTION
Discovered that sorting only takes place on the table data. Added a conditional check for filteredData, and sort on that if it exists. This fixes the issue where sorting doesn't work after filtering a column.